### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "reselect": "^4.0.0",
     "cookie-parser": "^1.4.3",
     "history": "^4.7.2",
-    "npm": "^6.9.0",
     "popper.js": "^1.15.0",
     "progressbar.js": "^1.0.1",
     "rc-progress": "^2.2.5",


### PR DESCRIPTION

Hello JamesODonoghue!

It seems like you have npm as one of your (dev-) dependency in SpotifyReactSandbox.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
